### PR TITLE
Small clean ups:

### DIFF
--- a/src/EventStore/DBALEventStore/DBALEventStore.php
+++ b/src/EventStore/DBALEventStore/DBALEventStore.php
@@ -1,14 +1,12 @@
 <?php
+
 namespace Rawkode\Eidetic\EventStore\DBALEventStore;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Schema\Schema;
 use Rawkode\Eidetic\EventStore\InvalidEventException;
 use Rawkode\Eidetic\EventStore\EventStore;
-use Rawkode\Eidetic\EventStore\VersionMismatchException;
-use Rawkode\Eidetic\EventStore\EntityDoesNotExistException;
 use Rawkode\Eidetic\EventStore\NoEventsFoundForKeyException;
 
 final class DBALEventStore implements EventStore
@@ -24,7 +22,7 @@ final class DBALEventStore implements EventStore
     private $dbalConnection;
 
     /**
-     * @param string $tableName
+     * @param string     $tableName
      * @param Connection $dbalConnection
      */
     private function __construct($tableName, Connection $dbalConnection)
@@ -34,8 +32,9 @@ final class DBALEventStore implements EventStore
     }
 
     /**
-     * @param  string $tableName
-     * @param  array  $options
+     * @param string $tableName
+     * @param array  $options
+     *
      * @return self
      */
     public static function createWithOptions($tableName, array $options)
@@ -45,10 +44,9 @@ final class DBALEventStore implements EventStore
         return new self($tableName, $connection);
     }
 
-
     /**
      * @param string $key
-     * @param array $events
+     * @param array  $events
      */
     public function saveEvents($key, array $events)
     {
@@ -58,8 +56,6 @@ final class DBALEventStore implements EventStore
             foreach ($events as $event) {
                 $this->persistEvent($key, $event);
             }
-        } catch (TransactionAlreadyInProgressException $transactionAlreadyInProgressExeception) {
-            throw $transactionAlreadyInProgressExeception;
         } catch (InvalidEventException $invalidEventException) {
             $this->abortTransaction();
 
@@ -95,6 +91,7 @@ final class DBALEventStore implements EventStore
 
     /**
      * @param string $key
+     *
      * @return array
      */
     private function getEventLogs($key)
@@ -166,7 +163,7 @@ final class DBALEventStore implements EventStore
             \PDO::PARAM_STR,
             'datetime',
             \PDO::PARAM_STR,
-            \PDO::PARAM_STR
+            \PDO::PARAM_STR,
         ]);
     }
 
@@ -204,9 +201,9 @@ final class DBALEventStore implements EventStore
         $serialNumberColumn->setAutoincrement(true);
         $table->setPrimaryKey(['serial_number']);
 
-        $table->addColumn('key', 'string', [ 'length' => 255 ]);
+        $table->addColumn('key', 'string', ['length' => 255]);
         $table->addColumn('recorded_at', 'datetime');
-        $table->addColumn('event_class', 'string', [ 'length' => 255 ]);
+        $table->addColumn('event_class', 'string', ['length' => 255]);
         $table->addColumn('event', 'text');
 
         $table->addIndex(['key']);

--- a/src/EventStore/InMemoryEventStore/InMemoryEventStore.php
+++ b/src/EventStore/InMemoryEventStore/InMemoryEventStore.php
@@ -5,12 +5,11 @@ namespace Rawkode\Eidetic\EventStore\InMemoryEventStore;
 use Rawkode\Eidetic\EventStore\InvalidEventException;
 use Rawkode\Eidetic\EventStore\EventStore;
 use Rawkode\Eidetic\EventStore\NoEventsFoundForKeyException;
-use Rawkode\Eidetic\EventStore\TransactionAlreadyInProgressException;
 
 final class InMemoryEventStore implements EventStore
 {
     /**
-     * @var integer
+     * @var int
      */
     private $serialNumber = 0;
 
@@ -46,7 +45,8 @@ final class InMemoryEventStore implements EventStore
     }
 
     /**
-     * @param  string $key
+     * @param string $key
+     *
      * @return array
      */
     public function fetchEventLogs($key)
@@ -55,7 +55,8 @@ final class InMemoryEventStore implements EventStore
     }
 
     /**
-     * @param  string $key
+     * @param string $key
+     *
      * @return array
      */
     private function getEventLogs($key)

--- a/src/EventStore/TransactionAlreadyInProgressException.php
+++ b/src/EventStore/TransactionAlreadyInProgressException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Rawkode\Eidetic\EventStore;
-
-final class TransactionAlreadyInProgressException extends \Exception
-{
-}

--- a/test/phpunit/integration/EventStore/EventStoreTest.php
+++ b/test/phpunit/integration/EventStore/EventStoreTest.php
@@ -37,7 +37,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_throws_no_events_for_key_exception_when_no_events_exist()
+    public function it_throws_an_exception_when_loading_an_invalid_key()
     {
         $this->setExpectedException('Rawkode\Eidetic\EventStore\NoEventsFoundForKeyException');
 
@@ -47,7 +47,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_can_save_and_fetch_events()
+    public function it_can_save_and_load_events_by_their_key()
     {
         $this->eventStore->saveEvents('uuid-1', $this->validEvents);
 
@@ -59,7 +59,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
      */
     public function it_saves_the_correct_event_log_meta_data()
     {
-        $now = new \DateTime("now", new \DateTimeZone("UTC"));
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $this->eventStore->saveEvents('uuid-1', $this->validEvents);
 
@@ -70,7 +70,6 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
 
         // Ensure event_class is saved correctly
         $this->assertEquals('stdClass', $eventLogs[0]['event_class']);
-
     }
 
     /**
@@ -83,7 +82,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
         $eventLogs = $this->eventStore->fetchEventLogs('uuid-1');
 
         $counter = 0;
-        
+
         array_map(function ($eventLog) {
             $this->assertEquals(++$counter, $eventLog['serial_number']);
         }, $eventLogs);
@@ -92,7 +91,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_throws_invalid_event_exception_when_event_is_not_an_object()
+    public function it_does_not_allow_events_that_are_not_objects()
     {
         $this->setExpectedException('Rawkode\Eidetic\EventStore\InvalidEventException');
 
@@ -102,7 +101,7 @@ abstract class EventStoreTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_rollbacks_the_transaction_during_an_exception()
+    public function it_can_rollback_a_transaction_after_an_error()
     {
         $this->eventStore->saveEvents('uuid-1', $this->validEvents);
 


### PR DESCRIPTION
- TransactionAlreadyInProgress is specific to InMemory EventStore
- Renaming tests to reveal the purpose, rather than describe what it does
